### PR TITLE
Update docs for HTTP invocation for tracing

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ For one-off requests, instantiate a fresh client:
 ```dart
 final httpClient = DatadogTracingHttpClient();
 // make requests
-final response = await httpClient.get('http://example.com');
+final response = await httpClient.get(Uri(string: 'http://example.com');
 ```
 
 For frameworks that use an internal client like Brick, compose the client:


### PR DESCRIPTION
This update to the docs just calls out that you need to pass in URI inside the get method instead of just passing in a string