### PR TITLE
platform exception fix for flutter web

### DIFF
--- a/lib/src/web/datadog_web_logger.dart
+++ b/lib/src/web/datadog_web_logger.dart
@@ -43,7 +43,7 @@ class DatadogWebLogger {
         return true;
       case 'loggerRemoveTag':
         return false;
-      case 'log':
+      case 'loggerLog':
         loggers[call.arguments['identifier']]?.log(
           call.arguments['message'],
           jsify(call.arguments['attributes'] ?? {}),


### PR DESCRIPTION

Issue:
Error: PlatformException(error, please create first, null, null)
  at Object.throw_ [as throw] @ http://localhost:57919/dart_sdk.js:5061:11
  at StandardMethodCodec.decodeEnvelope @ http://localhost:57919/packages/flutter/src/services/restoration.dart.lib.js:2286:19
  at MethodChannel._invokeMethod @ http://localhost:57919/packages/flutter/src/services/restoration.dart.lib.js:1528:47
  at _invokeMethod.next @ <anonymous>
  at <anonymous> @ http://localhost:57919/dart_sdk.js:38640:33
  at _RootZone.runUnary @ http://localhost:57919/dart_sdk.js:38511:59
  at _FutureListener.thenAwait.handleValue @ http://localhost:57919/dart_sdk.js:33713:29
  at handleValueCallback @ http://localhost:57919/dart_sdk.js:34265:49
  at Function._propagateToListeners @ http://localhost:57919/dart_sdk.js:34303:17
  at _Future.new.[_completeWithValue] @ http://localhost:57919/dart_sdk.js:34151:23
  at async._AsyncCallbackEntry.new.callback @ http://localhost:57919/dart_sdk.js:34172:35
  at Object._microtaskLoop @ http://localhost:57919/dart_sdk.js:38778:13
  at _startMicrotaskLoop @ http://localhost:57919/dart_sdk.js:38784:13
  at <anonymous> @ http://localhost:57919/dart_sdk.js:34519:9