### PR TITLE
Bumped Android SDK to 1.11.1

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -41,5 +41,5 @@ android {
 
 dependencies {
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-  implementation "com.datadoghq:dd-sdk-android:1.8.1"
+  implementation "com.datadoghq:dd-sdk-android:1.11.1"
 }


### PR DESCRIPTION
This pull request bumps the Android SDk from `1.8.1` to `1.11.1` to resolve a crash on Android 31. This resolves the crash in #85